### PR TITLE
search options breeds toggle bug fix

### DIFF
--- a/Views/Animals.tsx
+++ b/Views/Animals.tsx
@@ -63,7 +63,7 @@ const Animals: React.FC<AnimalsProps> = ({route}) => {
   useLayoutEffect(() => {
     const handleOptionsPress = () => {
       console.log('Settings Icon Pressed');
-      navigation.navigate(Routes.Options);
+      navigation.navigate(Routes.Options, {from: 'Animals'});
     };
     navigation.setOptions({
       headerRight: () => <UserOptions onPress={handleOptionsPress} />,

--- a/Views/Options.tsx
+++ b/Views/Options.tsx
@@ -15,8 +15,9 @@ import {
 import Breed from '../models/Breed';
 import en from '../strings/en.json';
 
-const Options: React.FC = () => {
+const Options: React.FC = ({route}) => {
   const dispatch = useDispatch();
+  const {from} = route.params;
   const searchParameters = useSelector(selectSearchParameters);
   const {distance, location, tagsPreferred, breedsPreferred} = searchParameters;
   const [displayZip, setDisplayZip] = useState(location.zipCode);
@@ -73,7 +74,7 @@ const Options: React.FC = () => {
   };
 
   const handleBreedPress = (breed: Breed) => {
-    if (breedsPreferred.length <= 1) {
+    if (breedsPreferred.length <= 1 && from !== 'petTypes') {
       return;
     }
     const index = breedsPreferred.findIndex(b => b.name === breed.name);

--- a/Views/PetTypes.tsx
+++ b/Views/PetTypes.tsx
@@ -47,7 +47,7 @@ const PetTypes: React.FC = () => {
   useLayoutEffect(() => {
     const handleOptionsPress = () => {
       console.log('Settings Icon Pressed');
-      navigation.navigate(Routes.Options);
+      navigation.navigate(Routes.Options, {from: 'petTypes'});
     };
     navigation.setOptions({
       headerRight: () => <UserOptions onPress={handleOptionsPress} />,

--- a/__tests__/Options.test.tsx
+++ b/__tests__/Options.test.tsx
@@ -10,7 +10,7 @@ describe('Options', () => {
   it('renders correctly', () => {
     renderedOptionsTree = renderer.create(
       <Provider store={store}>
-        <Options />
+        <Options route={{params: {from: 'hello'}}} />
       </Provider>,
     );
     expect(renderedOptionsTree.toJSON()).toMatchSnapshot();


### PR DESCRIPTION
allow the user to remove all breeds from the search options screen unless they're in the context of the animals search results, in which case you need to keep a minimum 1 breed option.